### PR TITLE
Pagespeed is outdated.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -12,14 +12,3 @@ handlers:
   upload: index.html
 - url: /.*
   script: _go_app
-
-pagespeed:
-  domains_to_rewrite:
-  - hugsasaservice.appspot.com
-  enabled_rewriters:
-  - MinifyCss
-  - CombineCss
-  - ProxyCss
-  - ProxyJs
-  - JsOptimize
-  - CombineJs

--- a/readme.md
+++ b/readme.md
@@ -6,3 +6,11 @@ View It Live: [HugsAsAService.appspot.com](http://hugsasaservice.appspot.com).
 This is an application to provide a restful endpoint for sending hugs.
 
 It's written in Golang, as an experiment.
+
+## How to run and install
+The application is running on google app engine. You can read more about installing and running app engine apps here: 
+https://cloud.google.com/appengine/docs/standard/go/tools/using-local-server
+
+After having installed the app engine you can run the application with the following command: `dev_appserver.py app.yaml`
+
+And see lots of hugs totally meant for you here: [http://localhost:8080/hugattack/The%20reader%20of%20this%20readme](http://localhost:8080/hugattack/The%20reader%20of%20this%20readme)


### PR DESCRIPTION
Pagespeed can no longer be used on google app engine.

Also updated the readme to add some more basic instructions to help anyone who wants to contribute, especially useful if they do not have experience with app engine, like I. :) 